### PR TITLE
Implement Save all/Save selected feature for PNG saving

### DIFF
--- a/BTITool/AboutWindow.cs
+++ b/BTITool/AboutWindow.cs
@@ -25,9 +25,10 @@ namespace BTITool
         private void AboutWindow_Load(object sender, EventArgs e)
         {
             Version appVersion = Assembly.GetExecutingAssembly().GetName().Version;
-            DateTime buildDate = new DateTime(2000, 1, 1).AddDays(appVersion.Build).AddSeconds(appVersion.Revision * 2);
+            // Unfortunately this doesn't work anymore, and the replacements are ugly IMO
+            //DateTime buildDate = new DateTime(2000, 1, 1).AddDays(appVersion.Build).AddSeconds(appVersion.Revision * 2);
 
-            labelVersion.Text = "[Build: " + buildDate.ToString(CultureInfo.InvariantCulture) + "]";
+            labelVersion.Text = "[Build: " + appVersion.ToString() + "]";
         }
     }
 }

--- a/BTITool/AboutWindow.resx
+++ b/BTITool/AboutWindow.resx
@@ -13381,6 +13381,8 @@
     <value />
   </data>
   <data name="textBoxDescription.Text" xml:space="preserve">
-    <value>Written in 2016 by Sage of Mirrors. Thanks to many people for their work in figuring out the BTI format. Special thanks to Chadderz for the BTI format support and Dmitry Brant for TGA support. Biggest thanks to LordNed, for helping me become a programmer. Updated 2021-11-15 Andrew Piroli</value>
+    <value>Written in 2016 by Sage of Mirrors. Thanks to many people for their work in figuring out the BTI format. Special thanks to Chadderz for the BTI format support and Dmitry Brant for TGA support. Biggest thanks to LordNed, for helping me become a programmer.
+
+Updated 2021-11-15 Andrew Piroli - Enabled Save All and Save Selected as bitmap export only.</value>
   </data>
 </root>

--- a/BTITool/AboutWindow.resx
+++ b/BTITool/AboutWindow.resx
@@ -13383,6 +13383,6 @@
   <data name="textBoxDescription.Text" xml:space="preserve">
     <value>Written in 2016 by Sage of Mirrors. Thanks to many people for their work in figuring out the BTI format. Special thanks to Chadderz for the BTI format support and Dmitry Brant for TGA support. Biggest thanks to LordNed, for helping me become a programmer.
 
-Updated 2021-11-15 Andrew Piroli - Enabled Save All and Save Selected as bitmap export only.</value>
+Updated 2021-11-15 Andrew Piroli - Implemented Save All and Save Selected functions - PNG export only!</value>
   </data>
 </root>

--- a/BTITool/AboutWindow.resx
+++ b/BTITool/AboutWindow.resx
@@ -13381,6 +13381,6 @@
     <value />
   </data>
   <data name="textBoxDescription.Text" xml:space="preserve">
-    <value>Written in 2016 by Sage of Mirrors. Thanks to many people for their work in figuring out the BTI format. Special thanks to Chadderz for the BTI format support and Dmitry Brant for TGA support. Biggest thanks to LordNed, for helping me become a programmer.</value>
+    <value>Written in 2016 by Sage of Mirrors. Thanks to many people for their work in figuring out the BTI format. Special thanks to Chadderz for the BTI format support and Dmitry Brant for TGA support. Biggest thanks to LordNed, for helping me become a programmer. Updated 2021-11-15 Andrew Piroli</value>
   </data>
 </root>

--- a/BTITool/App.config
+++ b/BTITool/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
     </startup>
 </configuration>

--- a/BTITool/BTITool.csproj
+++ b/BTITool/BTITool.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BTITool</RootNamespace>
     <AssemblyName>BTITool</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/BTITool/BinaryTextureImage.cs
+++ b/BTITool/BinaryTextureImage.cs
@@ -20,7 +20,7 @@ namespace BTITool
     /// 
     /// BTI files are stored both individually on disk and embedded within other file formats. 
     /// </summary>
-    public class BinaryTextureImage : INotifyPropertyChanged
+    public class BinaryTextureImage : INotifyPropertyChanged, IEquatable<BinaryTextureImage>
     {
         #region NotifyPropertyChanged overhead
         public event PropertyChangedEventHandler PropertyChanged;
@@ -1282,6 +1282,57 @@ namespace BTITool
                 return true;
             else
                 return false;
+        }
+
+        public bool Equals(BinaryTextureImage other)
+        {
+            return other != null &&
+                   Name == other.Name &&
+                   Format == other.Format &&
+                   AlphaSetting == other.AlphaSetting &&
+                   Width == other.Width &&
+                   Height == other.Height &&
+                   WrapS == other.WrapS &&
+                   WrapT == other.WrapT &&
+                   PaletteFormat == other.PaletteFormat &&
+                   PaletteCount == other.PaletteCount &&
+                   EqualityComparer<Color32>.Default.Equals(BorderColor, other.BorderColor) &&
+                   MinFilter == other.MinFilter &&
+                   MagFilter == other.MagFilter &&
+                   MinLOD == other.MinLOD &&
+                   MagLOD == other.MagLOD &&
+                   MipMapCount == other.MipMapCount &&
+                   LodBias == other.LodBias &&
+                   EqualityComparer<System.Windows.Media.Imaging.BitmapSource>.Default.Equals(DisplaySource, other.DisplaySource) &&
+                   EqualityComparer<System.Windows.Media.Imaging.BitmapSource>.Default.Equals(m_displaySource, other.m_displaySource) &&
+                   EqualityComparer<Palette>.Default.Equals(m_imagePalette, other.m_imagePalette) &&
+                   EqualityComparer<byte[]>.Default.Equals(m_rgbaImageData, other.m_rgbaImageData);
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1897818637;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Name);
+            hashCode = hashCode * -1521134295 + Format.GetHashCode();
+            hashCode = hashCode * -1521134295 + AlphaSetting.GetHashCode();
+            hashCode = hashCode * -1521134295 + Width.GetHashCode();
+            hashCode = hashCode * -1521134295 + Height.GetHashCode();
+            hashCode = hashCode * -1521134295 + WrapS.GetHashCode();
+            hashCode = hashCode * -1521134295 + WrapT.GetHashCode();
+            hashCode = hashCode * -1521134295 + PaletteFormat.GetHashCode();
+            hashCode = hashCode * -1521134295 + PaletteCount.GetHashCode();
+            hashCode = hashCode * -1521134295 + BorderColor.GetHashCode();
+            hashCode = hashCode * -1521134295 + MinFilter.GetHashCode();
+            hashCode = hashCode * -1521134295 + MagFilter.GetHashCode();
+            hashCode = hashCode * -1521134295 + MinLOD.GetHashCode();
+            hashCode = hashCode * -1521134295 + MagLOD.GetHashCode();
+            hashCode = hashCode * -1521134295 + MipMapCount.GetHashCode();
+            hashCode = hashCode * -1521134295 + LodBias.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<System.Windows.Media.Imaging.BitmapSource>.Default.GetHashCode(DisplaySource);
+            hashCode = hashCode * -1521134295 + EqualityComparer<System.Windows.Media.Imaging.BitmapSource>.Default.GetHashCode(m_displaySource);
+            hashCode = hashCode * -1521134295 + EqualityComparer<Palette>.Default.GetHashCode(m_imagePalette);
+            hashCode = hashCode * -1521134295 + EqualityComparer<byte[]>.Default.GetHashCode(m_rgbaImageData);
+            return hashCode;
         }
 
         public static bool operator ==(BinaryTextureImage left, BinaryTextureImage right)

--- a/BTITool/MainWindow.xaml
+++ b/BTITool/MainWindow.xaml
@@ -18,8 +18,8 @@
             <Menu Margin="0,0,0,0" Height="20" DockPanel.Dock="Top">
                 <MenuItem Header="_File">
                     <MenuItem Header="_Open..." Command="{Binding OnRequestOpenImages}"/>
-                    <MenuItem Header="_Save Selected..." Command="{Binding OnRequestOpenWiki}"/>
-                    <MenuItem Header="Save _All..." Command="{Binding OnRequestReportBug}"/>
+                    <MenuItem Header="_Save Selected..." Command="{Binding OnRequestOpenWiki}" IsEnabled="False"/>
+                    <MenuItem Header="Save _All..." Command="{Binding SaveAll, Mode=OneWay}"/>
                     <Separator/>
                     <MenuItem Header="_Clear List" Command="{Binding OnRequestClearList}"/>
                 </MenuItem>
@@ -52,7 +52,7 @@
         <DockPanel LastChildFill="True" Height="144" VerticalAlignment="Bottom">
             <Grid>
                 <Button Content="Add File(s)..." Command="{Binding OnRequestOpenImages}" Margin="10,0,10,102" Height="41" VerticalAlignment="Bottom"/>
-                <Button Content="Save All..." Margin="10,0,10,56" Height="41" VerticalAlignment="Bottom"/>
+                <Button Content="Save All..." Margin="10,0,10,56" Height="41" VerticalAlignment="Bottom" Command="{Binding SaveAll, Mode=OneWay}"/>
                 <Button Content="Clear List" Command="{Binding OnRequestClearList}" Margin="10,0,10,10" Height="41" VerticalAlignment="Bottom"/>
             </Grid>
         </DockPanel>

--- a/BTITool/MainWindow.xaml
+++ b/BTITool/MainWindow.xaml
@@ -18,7 +18,7 @@
             <Menu Margin="0,0,0,0" Height="20" DockPanel.Dock="Top">
                 <MenuItem Header="_File">
                     <MenuItem Header="_Open..." Command="{Binding OnRequestOpenImages}"/>
-                    <MenuItem Header="_Save Selected..." Command="{Binding OnRequestOpenWiki}" IsEnabled="False"/>
+                    <MenuItem Header="_Save Selected..." Command="{Binding SaveSelected, Mode=OneWay}" CommandParameter="{Binding ElementName=listBox, Mode=OneWay}"/>
                     <MenuItem Header="Save _All..." Command="{Binding SaveAll, Mode=OneWay}"/>
                     <Separator/>
                     <MenuItem Header="_Clear List" Command="{Binding OnRequestClearList}"/>
@@ -32,7 +32,11 @@
         </DockPanel>
         <DockPanel LastChildFill="True" Margin="0,20,0,144">
             <Grid>
-                <ListBox Margin="10,10,9,10" ItemsSource="{Binding ImageList}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="5*"/>
+                    <ColumnDefinition Width="88*"/>
+                </Grid.ColumnDefinitions>
+                <ListBox x:Name="listBox" Margin="10,10,8.667,9.667" ItemsSource="{Binding ImageList}" Grid.ColumnSpan="2">
                     <ListBox.ItemTemplate>
                         <DataTemplate DataType="local:BinaryTextureImage">
                             <StackPanel Orientation="Horizontal">

--- a/BTITool/MainWindow.xaml
+++ b/BTITool/MainWindow.xaml
@@ -36,7 +36,7 @@
                     <ColumnDefinition Width="5*"/>
                     <ColumnDefinition Width="88*"/>
                 </Grid.ColumnDefinitions>
-                <ListBox x:Name="listBox" Margin="10,10,8.667,9.667" ItemsSource="{Binding ImageList}" Grid.ColumnSpan="2">
+                <ListBox x:Name="listBox" Margin="10,10,8.667,9.667" ItemsSource="{Binding ImageList}" Grid.ColumnSpan="2" SelectionMode="Extended">
                     <ListBox.ItemTemplate>
                         <DataTemplate DataType="local:BinaryTextureImage">
                             <StackPanel Orientation="Horizontal">

--- a/BTITool/Properties/AssemblyInfo.cs
+++ b/BTITool/Properties/AssemblyInfo.cs
@@ -10,9 +10,9 @@ using System.Windows;
 [assembly: AssemblyTitle("BTITool")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Windows User")]
+[assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("BTITool")]
-[assembly: AssemblyCopyright("Copyright © Windows User 2016")]
+[assembly: AssemblyCopyright("")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -51,5 +51,5 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/BTITool/Properties/Resources.Designer.cs
+++ b/BTITool/Properties/Resources.Designer.cs
@@ -8,10 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace BTITool.Properties
-{
-
-
+namespace BTITool.Properties {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -19,51 +19,43 @@ namespace BTITool.Properties
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources
-    {
-
+    internal class Resources {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources()
-        {
+        internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if ((resourceMan == null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("BTITool.Properties.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }

--- a/BTITool/Properties/Settings.Designer.cs
+++ b/BTITool/Properties/Settings.Designer.cs
@@ -8,21 +8,17 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace BTITool.Properties
-{
-
-
+namespace BTITool.Properties {
+    
+    
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "11.0.0.0")]
-    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase
-    {
-
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.8.1.0")]
+    internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
+        
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
-
-        public static Settings Default
-        {
-            get
-            {
+        
+        public static Settings Default {
+            get {
                 return defaultInstance;
             }
         }

--- a/BTITool/ViewModel.cs
+++ b/BTITool/ViewModel.cs
@@ -105,7 +105,20 @@ namespace BTITool
 
         private void SaveAllImages()
         {
-
+            if (ImageList == null)
+            {
+                return;
+            }
+            foreach (BinaryTextureImage img in ImageList)
+            {
+                SaveFileDialog saveFile = new SaveFileDialog();
+                saveFile.FileName = System.IO.Path.GetFileNameWithoutExtension(img.Name);
+                saveFile.DefaultExt = ".bmp";
+                if (saveFile.ShowDialog() == true) //nullable bool, have to explicitly compare against true
+                {
+                    img.SaveImageToDisk(saveFile.FileName, img.GetData(), img.Width, img.Height);
+                }
+            }
         }
 
         private void ClearImageList()
@@ -128,6 +141,10 @@ namespace BTITool
         #endregion
 
         #region Command Callbacks
+        public ICommand SaveAll
+        {
+            get { return new RelayCommand(x => SaveAllImages());  }
+        }
         /// <summary> The user has requested to open an image/some images. </summary>
         public ICommand OnRequestOpenImages
         {

--- a/BTITool/ViewModel.cs
+++ b/BTITool/ViewModel.cs
@@ -114,6 +114,9 @@ namespace BTITool
                 SaveFileDialog saveFile = new SaveFileDialog();
                 saveFile.FileName = System.IO.Path.GetFileNameWithoutExtension(img.Name);
                 saveFile.DefaultExt = ".bmp";
+                saveFile.Filter = "Bitmap Graphics (*.bmp)|*.bmp|All Files (*.*)|*.*";
+                saveFile.FilterIndex = 0;
+                saveFile.RestoreDirectory = true;
                 if (saveFile.ShowDialog() == true) //nullable bool, have to explicitly compare against true
                 {
                     img.SaveImageToDisk(saveFile.FileName, img.GetData(), img.Width, img.Height);

--- a/BTITool/ViewModel.cs
+++ b/BTITool/ViewModel.cs
@@ -129,7 +129,7 @@ namespace BTITool
                 SaveFileDialog saveFile = new SaveFileDialog();
                 saveFile.FileName = System.IO.Path.GetFileNameWithoutExtension(img.Name);
                 saveFile.DefaultExt = ".bmp";
-                saveFile.Filter = "Bitmap Graphics (*.bmp)|*.bmp|All Files (*.*)|*.*";
+                saveFile.Filter = "PNG Image (*.png)|*.png|All Files (*.*)|*.*";
                 saveFile.FilterIndex = 0;
                 saveFile.RestoreDirectory = true;
                 if (saveFile.ShowDialog() == true) //nullable bool, have to explicitly compare against true

--- a/BTITool/ViewModel.cs
+++ b/BTITool/ViewModel.cs
@@ -134,7 +134,7 @@ namespace BTITool
                 }
                 SaveFileDialog saveFile = new SaveFileDialog();
                 saveFile.FileName = System.IO.Path.GetFileNameWithoutExtension(img.Name);
-                saveFile.DefaultExt = ".bmp";
+                saveFile.DefaultExt = ".png";
                 saveFile.Filter = "PNG Image (*.png)|*.png|All Files (*.*)|*.*";
                 saveFile.FilterIndex = 0;
                 saveFile.RestoreDirectory = true;

--- a/BTITool/ViewModel.cs
+++ b/BTITool/ViewModel.cs
@@ -98,19 +98,34 @@ namespace BTITool
             return tempList;
         }
 
-        private void SaveSelectedImages()
+        private void SaveSelectedImages(object theWholeListBox_sorry) // I'm sorry, this is the easiest way.
         {
-
+            try
+            {
+                System.Windows.Controls.ListBox imagesListBox = theWholeListBox_sorry as System.Windows.Controls.ListBox;
+                if (imagesListBox == null)
+                {
+                    return;
+                }
+                System.Collections.IList selected = (System.Collections.IList)imagesListBox.SelectedItems;
+                InternalSave(selected.Cast<BinaryTextureImage>());
+            }
+            catch (InvalidCastException){ }
         }
 
         private void SaveAllImages()
         {
-            if (ImageList == null)
+            InternalSave(ImageList);
+        }
+
+        private void InternalSave(IEnumerable<BinaryTextureImage> toSave)
+        {
+            foreach (BinaryTextureImage img in toSave)
             {
-                return;
-            }
-            foreach (BinaryTextureImage img in ImageList)
-            {
+                if (img == null)
+                {
+                    continue;
+                }
                 SaveFileDialog saveFile = new SaveFileDialog();
                 saveFile.FileName = System.IO.Path.GetFileNameWithoutExtension(img.Name);
                 saveFile.DefaultExt = ".bmp";
@@ -144,9 +159,13 @@ namespace BTITool
         #endregion
 
         #region Command Callbacks
+        public ICommand SaveSelected
+        {
+            get { return new RelayCommand(SaveSelectedImages); }
+        }
         public ICommand SaveAll
         {
-            get { return new RelayCommand(x => SaveAllImages());  }
+            get { return new RelayCommand(x => SaveAllImages(), x=> ImageList != null); }
         }
         /// <summary> The user has requested to open an image/some images. </summary>
         public ICommand OnRequestOpenImages

--- a/BTITool/ViewModel.cs
+++ b/BTITool/ViewModel.cs
@@ -91,8 +91,14 @@ namespace BTITool
 
                     openedImage = new BinaryTextureImage(path, input, BinaryTextureImage.TextureFormats.TGA);
                 }
-
-                tempList.Add(openedImage);
+                else
+                {
+                    continue;
+                }
+                if (openedImage != null)
+                {
+                    tempList.Add(openedImage);
+                }
             }
 
             return tempList;


### PR DESCRIPTION
This tool is near the top of search results if you search for how to convert a Nintendo .bti to png. While other tools can also do it, they can be hard to find for outsiders.

I thought I would contribute the last little bit needed to get it functional. 
I have a compiled version here: https://github.com/AndrewPiroli/BTITool/releases/tag/v1.1.0 if you want to use that to provide a binary as well.

This should close issue #1 